### PR TITLE
Add sparklens data file conf option

### DIFF
--- a/src/main/scala/com/qubole/sparklens/package.scala
+++ b/src/main/scala/com/qubole/sparklens/package.scala
@@ -4,6 +4,10 @@ import org.apache.spark.SparkConf
 
 package object sparklens {
 
+  private [qubole] def getDumpFile(conf: SparkConf): String = {
+    conf.get("spark.sparklens.data.file", "")
+  }
+
   private [qubole] def getDumpDirectory(conf: SparkConf): String = {
     conf.get("spark.sparklens.data.dir", "/tmp/sparklens/")
   }


### PR DESCRIPTION
Currently, a user can only specify a folder path, and the file path was automatically chosen as a combination of app ID and timestamp. It then makes it hard for a user to retrieve the metrics file generated by sparklens without manually looking at the file.

This PR adds a file path configuration option to allow the user to name the metrics file sparklens is writing data to.

If a file path is specified, it takes precedence over the folder path configuration option.